### PR TITLE
fix(tests): align createTestUser with auth controller contract

### DIFF
--- a/backend/src/__tests__/helpers.js
+++ b/backend/src/__tests__/helpers.js
@@ -3,15 +3,22 @@ const app = require('../app');
 
 /**
  * Register + login a test user, return { user, accessToken, refreshToken }
+ *
+ * The registration endpoint expects snake_case fields:
+ *   pseudo, email, password, birth_date, cgu_accepted
+ * and returns:
+ *   { user, access_token, refresh_token }
  */
 async function createTestUser(overrides = {}) {
   const unique = Date.now() + Math.random().toString(36).slice(2, 7);
   const payload = {
-    pseudo: overrides.pseudo || `user_${unique}`,
-    email: overrides.email || `test_${unique}@example.com`,
+    pseudo: overrides.pseudo || `user${unique}`,          // alphanumeric only
+    email: overrides.email || `test${unique}@example.com`,
     password: overrides.password || 'Password123!',
-    birthDate: overrides.birthDate || '2000-01-01',
-    acceptedCgu: overrides.acceptedCgu !== undefined ? overrides.acceptedCgu : true,
+    birth_date: overrides.birth_date || '2000-01-01',     // snake_case — required by controller
+    cgu_accepted: overrides.cgu_accepted !== undefined
+      ? overrides.cgu_accepted
+      : true,                                             // snake_case — required by controller
     ...overrides,
   };
 
@@ -19,9 +26,9 @@ async function createTestUser(overrides = {}) {
   if (regRes.status !== 201) throw new Error(`createTestUser failed: ${JSON.stringify(regRes.body)}`);
 
   return {
-    user: regRes.body.data.user,
-    accessToken: regRes.body.data.accessToken,
-    refreshToken: regRes.body.data.refreshToken,
+    user: regRes.body.user,                  // controller returns { user, access_token, refresh_token }
+    accessToken: regRes.body.access_token,
+    refreshToken: regRes.body.refresh_token,
   };
 }
 


### PR DESCRIPTION
The register endpoint (auth.controller.js) uses snake_case fields (birth_date, cgu_accepted) and returns { user, access_token, refresh_token }.

The previous helper was sending camelCase fields (birthDate, acceptedCgu) and reading from a non-existent regRes.body.data wrapper, causing all 21 tests to fail at the createTestUser step.

Changes:
- Rename birthDate → birth_date to match controller destructuring
- Rename acceptedCgu → cgu_accepted to match controller destructuring
- Fix pseudo to be strictly alphanumeric (controller/Joi rejects underscores)
- Fix response reading: body.user / body.access_token / body.refresh_token (no .data wrapper in the controller response)