### PR TITLE
feat(notifications): in-app + push notification system (#6)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const express    = require('express');
-const cors       = require('cors');
-const helmet     = require('helmet');
-const path       = require('path');
+const express = require('express');
+const cors    = require('cors');
+const helmet  = require('helmet');
+const path    = require('path');
 
-const corsConfig    = require('./config/cors');
-const requestId     = require('./middlewares/requestId');
-const httpLogger    = require('./middlewares/httpLogger');
-const errorHandler  = require('./middlewares/errorHandler');
+const corsConfig   = require('./config/cors');
+const requestId    = require('./middlewares/requestId');
+const httpLogger   = require('./middlewares/httpLogger');
+const errorHandler = require('./middlewares/errorHandler');
 const { authLimiter, globalLimiter } = require('./middlewares/rateLimiter');
-const { error }     = require('./utils/response');
+const { error }    = require('./utils/response');
 
 const authRoutes           = require('./routes/auth.routes');
 const profileRoutes        = require('./routes/profile.routes');
@@ -20,47 +20,46 @@ const searchRoutes         = require('./routes/search.routes');
 const exchangesRoutes      = require('./routes/exchanges.routes');
 const reviewsRoutes        = require('./routes/reviews.routes');
 const healthRoutes         = require('./routes/health.routes');
+const notificationsRoutes  = require('./routes/notifications.routes');
 
 const app = express();
 
-// ─── Security ───────────────────────────────────────────────
+// ─── Security ────────────────────────────────────────────────────────
 app.use(helmet({
-  contentSecurityPolicy:       true,
-  crossOriginEmbedderPolicy:   true,
-  crossOriginOpenerPolicy:     true,
-  crossOriginResourcePolicy:   true,
+  contentSecurityPolicy:     true,
+  crossOriginEmbedderPolicy: true,
+  crossOriginOpenerPolicy:   true,
+  crossOriginResourcePolicy: true,
   hsts: { maxAge: 31536000, includeSubDomains: true },
 }));
-
-// Tightened CORS: dev=open, production=allowlist from ALLOWED_ORIGINS
 app.use(cors(corsConfig));
 
-// ─── Observability ──────────────────────────────────────────
-// requestId must come before httpLogger so req.id is available
+// ─── Observability ───────────────────────────────────────────────────
 app.use(requestId);
 app.use(httpLogger);
 
-// ─── Rate limiting ──────────────────────────────────────────
+// ─── Rate limiting ───────────────────────────────────────────────────
 app.use(globalLimiter);
 
-// ─── Body parsers ───────────────────────────────────────────
+// ─── Body parsers ────────────────────────────────────────────────────
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true }));
 
-// ─── Static files ───────────────────────────────────────────
+// ─── Static files ────────────────────────────────────────────────────
 app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
 
-// ─── Routes ─────────────────────────────────────────────────
-app.use('/health',                    healthRoutes);
-app.use('/api/v1/auth',               authLimiter, authRoutes);
-app.use('/api/v1/profile',            profileRoutes);
-app.use('/api/v1/skills',             skillsRoutes);
-app.use('/api/v1/availabilities',     availabilitiesRoutes);
-app.use('/api/v1/search',             searchRoutes);
-app.use('/api/v1/exchanges',          exchangesRoutes);
-app.use('/api/v1/users',              reviewsRoutes);
+// ─── Routes ──────────────────────────────────────────────────────────
+app.use('/health',                     healthRoutes);
+app.use('/api/v1/auth',                authLimiter, authRoutes);
+app.use('/api/v1/profile',             profileRoutes);
+app.use('/api/v1/skills',              skillsRoutes);
+app.use('/api/v1/availabilities',      availabilitiesRoutes);
+app.use('/api/v1/search',              searchRoutes);
+app.use('/api/v1/exchanges',           exchangesRoutes);
+app.use('/api/v1/users',               reviewsRoutes);
+app.use('/api/v1/notifications',       notificationsRoutes);
 
-// ─── Fallthrough & error handlers ───────────────────────────
+// ─── Fallthrough & error handlers ────────────────────────────────────
 app.use((_req, res) => error(res, 404, 'NOT_FOUND', 'Route not found.'));
 app.use(errorHandler);
 

--- a/backend/src/controllers/exchanges.controller.js
+++ b/backend/src/controllers/exchanges.controller.js
@@ -1,28 +1,32 @@
-const pool = require('../database/db');
+'use strict';
+
+const pool   = require('../database/db');
 const { success, error } = require('../utils/response');
 const { computeCompatibilityScore } = require('../services/matching.service');
 const { applyExchangeCredits, hasEnoughCredits } = require('../services/credits.service');
+const { createNotification } = require('../services/notification.service');
 const logger = require('../utils/logger');
 
 // ─── CREATE ───────────────────────────────────────────────────────────
 
+/**
+ * POST /api/v1/exchanges
+ * Create a new exchange request. Emits `exchange_request` notification to partner.
+ */
 async function createExchange(req, res) {
   const requesterId = req.user.id;
   const { partner_id, skill_id, duration_minutes, desired_date, message } = req.body;
 
-  // Prevent self-exchange
   if (requesterId === partner_id) {
     return error(res, 400, 'INVALID_REQUEST', 'You cannot request an exchange with yourself.');
   }
 
-  // Credit check
   const enough = await hasEnoughCredits(requesterId).catch(() => false);
   if (!enough) {
     return error(res, 400, 'INSUFFICIENT_CREDITS', 'You need at least 1 credit to request an exchange.');
   }
 
   try {
-    // Compute compatibility score
     const [requesterSlots, partnerSlots, requesterWanted, partnerOffered] = await Promise.all([
       pool.query('SELECT day_of_week FROM availabilities WHERE user_id = $1', [requesterId]),
       pool.query('SELECT day_of_week FROM availabilities WHERE user_id = $1', [partner_id]),
@@ -32,15 +36,15 @@ async function createExchange(req, res) {
                   WHERE us.user_id = $1 AND us.skill_id = $2 AND us.type = 'offered'`, [partner_id, skill_id]),
     ]);
 
-    const wantedLevel  = requesterWanted.rows[0]?.level  || 'beginner';
-    const offeredData  = partnerOffered.rows[0] || {};
+    const wantedLevel = requesterWanted.rows[0]?.level || 'beginner';
+    const offeredData = partnerOffered.rows[0] || {};
     const score = computeCompatibilityScore({
       wantedLevel,
-      offeredLevel:     offeredData.level          || 'beginner',
+      offeredLevel:     offeredData.level         || 'beginner',
       requesterSlots:   requesterSlots.rows,
       partnerSlots:     partnerSlots.rows,
-      partnerRating:    offeredData.average_rating  || null,
-      partnerExchanges: offeredData.exchange_count  || 0,
+      partnerRating:    offeredData.average_rating || null,
+      partnerExchanges: offeredData.exchange_count || 0,
     });
 
     const result = await pool.query(
@@ -50,8 +54,20 @@ async function createExchange(req, res) {
        RETURNING *`,
       [requesterId, partner_id, skill_id, duration_minutes || 60, desired_date || null, message || '', score]
     );
+    const exchange = result.rows[0];
 
-    return success(res, result.rows[0], 201);
+    // Notify partner of incoming request
+    createNotification({
+      userId:  partner_id,
+      type:    'exchange_request',
+      payload: {
+        exchangeId:      exchange.id,
+        requesterPseudo: req.user.pseudo,
+        skillId:         skill_id,
+      },
+    }).catch(err => logger.warn('notification failed', { error: err.message }));
+
+    return success(res, exchange, 201);
   } catch (err) {
     logger.error('createExchange error', { error: err.message });
     return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
@@ -60,9 +76,13 @@ async function createExchange(req, res) {
 
 // ─── LIST ─────────────────────────────────────────────────────────────
 
+/**
+ * GET /api/v1/exchanges
+ * List exchanges for the authenticated user. Supports ?status and ?role filters.
+ */
 async function listExchanges(req, res) {
   const userId = req.user.id;
-  const { status, role } = req.query; // role: sent | received | all
+  const { status, role } = req.query;
 
   let condition = '(e.requester_id = $1 OR e.partner_id = $1)';
   if (role === 'sent')     condition = 'e.requester_id = $1';
@@ -79,13 +99,13 @@ async function listExchanges(req, res) {
     const result = await pool.query(
       `SELECT
          e.*,
-         s.name  AS skill_name,
+         s.name AS skill_name,
          json_build_object('id', r.id, 'pseudo', r.pseudo, 'photo_url', r.photo_url, 'average_rating', r.average_rating) AS requester,
          json_build_object('id', p.id, 'pseudo', p.pseudo, 'photo_url', p.photo_url, 'average_rating', p.average_rating) AS partner
        FROM exchanges e
-       JOIN skills s  ON s.id  = e.skill_id
-       JOIN users  r  ON r.id  = e.requester_id
-       JOIN users  p  ON p.id  = e.partner_id
+       JOIN skills s ON s.id = e.skill_id
+       JOIN users  r ON r.id = e.requester_id
+       JOIN users  p ON p.id = e.partner_id
        WHERE ${condition} ${statusClause}
        ORDER BY e.created_at DESC`,
       params
@@ -99,6 +119,10 @@ async function listExchanges(req, res) {
 
 // ─── GET ONE ──────────────────────────────────────────────────────────
 
+/**
+ * GET /api/v1/exchanges/:exchangeId
+ * Fetch a single exchange the authenticated user participates in.
+ */
 async function getExchange(req, res) {
   const userId = req.user.id;
   const { exchangeId } = req.params;
@@ -122,12 +146,16 @@ async function getExchange(req, res) {
   }
 }
 
-// ─── RESPOND (accept / cancel) ───────────────────────────────────────────
+// ─── RESPOND (accept / cancel) ────────────────────────────────────────
 
+/**
+ * PATCH /api/v1/exchanges/:exchangeId/respond
+ * Accept or cancel an exchange. Emits exchange_accepted / exchange_cancelled notification.
+ */
 async function respondExchange(req, res) {
   const userId = req.user.id;
   const { exchangeId } = req.params;
-  const { action } = req.body; // 'accept' | 'cancel'
+  const { action } = req.body;
 
   if (!['accept', 'cancel'].includes(action)) {
     return error(res, 400, 'VALIDATION_ERROR', 'action must be accept or cancel.');
@@ -137,9 +165,9 @@ async function respondExchange(req, res) {
     const exch = await pool.query('SELECT * FROM exchanges WHERE id = $1', [exchangeId]);
     if (exch.rowCount === 0) return error(res, 404, 'NOT_FOUND', 'Exchange not found.');
 
-    const ex = exch.rows[0];
-    const isPartner    = ex.partner_id    === userId;
-    const isRequester  = ex.requester_id  === userId;
+    const ex         = exch.rows[0];
+    const isPartner   = ex.partner_id   === userId;
+    const isRequester = ex.requester_id === userId;
 
     if (!isPartner && !isRequester) {
       return error(res, 403, 'FORBIDDEN', 'Not your exchange.');
@@ -147,7 +175,6 @@ async function respondExchange(req, res) {
     if (ex.status !== 'pending') {
       return error(res, 400, 'INVALID_STATE', `Exchange is already ${ex.status}.`);
     }
-    // Only the partner can accept; both can cancel
     if (action === 'accept' && !isPartner) {
       return error(res, 403, 'FORBIDDEN', 'Only the partner can accept.');
     }
@@ -157,15 +184,31 @@ async function respondExchange(req, res) {
       'UPDATE exchanges SET status = $1 WHERE id = $2 RETURNING *',
       [newStatus, exchangeId]
     );
-    return success(res, result.rows[0]);
+    const updated = result.rows[0];
+
+    // Notify the other participant
+    const notifyUserId = isPartner ? ex.requester_id : ex.partner_id;
+    const notifType    = action === 'accept' ? 'exchange_accepted' : 'exchange_cancelled';
+    createNotification({
+      userId:  notifyUserId,
+      type:    notifType,
+      payload: { exchangeId, actorPseudo: req.user.pseudo },
+    }).catch(err => logger.warn('notification failed', { error: err.message }));
+
+    return success(res, updated);
   } catch (err) {
     logger.error('respondExchange error', { error: err.message });
     return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
   }
 }
 
-// ─── CONFIRM COMPLETION (Sprint 4) ──────────────────────────────────────
+// ─── CONFIRM COMPLETION ──────────────────────────────────────────────
 
+/**
+ * PATCH /api/v1/exchanges/:exchangeId/confirm
+ * Both participants must confirm to mark exchange as completed.
+ * Emits exchange_completed notification when both sides confirm.
+ */
 async function confirmExchange(req, res) {
   const userId = req.user.id;
   const { exchangeId } = req.params;
@@ -183,7 +226,7 @@ async function confirmExchange(req, res) {
       return error(res, 404, 'NOT_FOUND', 'Exchange not found.');
     }
 
-    const ex = exch.rows[0];
+    const ex          = exch.rows[0];
     const isRequester = ex.requester_id === userId;
     const isPartner   = ex.partner_id   === userId;
 
@@ -196,7 +239,6 @@ async function confirmExchange(req, res) {
       return error(res, 400, 'INVALID_STATE', 'Exchange must be accepted before confirming.');
     }
 
-    // Set the correct confirmation flag
     const updateField = isRequester ? 'confirmed_by_requester' : 'confirmed_by_partner';
     const updated = await client.query(
       `UPDATE exchanges SET ${updateField} = TRUE WHERE id = $1 RETURNING *`,
@@ -204,20 +246,24 @@ async function confirmExchange(req, res) {
     );
     const updatedEx = updated.rows[0];
 
-    // If both have confirmed → complete the exchange + apply credits
     if (updatedEx.confirmed_by_requester && updatedEx.confirmed_by_partner) {
       await client.query(
         "UPDATE exchanges SET status = 'completed' WHERE id = $1",
         [exchangeId]
       );
       updatedEx.status = 'completed';
-
-      // Skill teacher = partner (they offered), learner = requester
       await applyExchangeCredits(client, ex.partner_id, ex.requester_id);
+
+      // Notify both participants that exchange is completed
+      const notifPayload = { exchangeId };
+      createNotification({ userId: ex.requester_id, type: 'exchange_completed', payload: notifPayload })
+        .catch(err => logger.warn('notification failed', { error: err.message }));
+      createNotification({ userId: ex.partner_id,   type: 'exchange_completed', payload: notifPayload })
+        .catch(err => logger.warn('notification failed', { error: err.message }));
     }
 
     await client.query('COMMIT');
-    return success(res, { ...updatedEx });
+    return success(res, updatedEx);
   } catch (err) {
     await client.query('ROLLBACK');
     logger.error('confirmExchange error', { error: err.message });

--- a/backend/src/controllers/notifications.controller.js
+++ b/backend/src/controllers/notifications.controller.js
@@ -1,138 +1,137 @@
 'use strict';
 
-const pool           = require('../database/db');
+const pool   = require('../database/db');
 const { success, error } = require('../utils/response');
-const logger         = require('../utils/logger');
+const logger = require('../utils/logger');
+const { z }  = require('zod');
 
-const PAGE_SIZE_MAX = 50;
-const PAGE_SIZE_DEFAULT = 20;
+// ── Zod schemas ────────────────────────────────────────────────────────
+
+const registerTokenSchema = z.object({
+  expo_push_token: z.string().min(1).max(200),
+});
+
+// ── Controllers ────────────────────────────────────────────────────────
 
 /**
  * GET /api/v1/notifications
+ * Returns paginated notifications for the authenticated user,
+ * ordered newest-first, with unread count in meta.
  *
- * Returns the authenticated user’s notifications, unread first then
- * newest-first within each group.  Supports cursor-based pagination
- * via `before` (a notification `created_at` ISO timestamp).
- *
- * Query params:
- *   limit  {number}  1–50, default 20
- *   before {string}  ISO timestamp cursor (exclusive)
- *
- * Response shape:
- *   { data: { notifications: [...], unread_count: N }, meta: { ... } }
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
  */
 async function listNotifications(req, res) {
   const userId = req.user.id;
-  const limit  = Math.min(parseInt(req.query.limit) || PAGE_SIZE_DEFAULT, PAGE_SIZE_MAX);
-  const before = req.query.before || null;
+  const limit  = Math.min(parseInt(req.query.limit,  10) || 20, 100);
+  const offset = Math.max(parseInt(req.query.offset, 10) || 0,  0);
 
   try {
-    const params = [userId];
-    let cursorClause = '';
-    if (before) {
-      params.push(before);
-      cursorClause = `AND n.created_at < $${params.length}::timestamptz`;
-    }
-
-    const [notifResult, countResult] = await Promise.all([
+    const [rows, total, unread] = await Promise.all([
       pool.query(
-        `SELECT id, type, payload, read_at, created_at
-         FROM notifications n
-         WHERE user_id = $1 ${cursorClause}
-         ORDER BY
-           (read_at IS NOT NULL),   -- unread (NULL) sorts before read
-           created_at DESC
-         LIMIT ${limit}`,
-        params
+        `SELECT * FROM notifications
+         WHERE user_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [userId, limit, offset]
       ),
+      pool.query('SELECT COUNT(*) FROM notifications WHERE user_id = $1', [userId]),
       pool.query(
-        'SELECT COUNT(*)::int AS unread_count FROM notifications WHERE user_id = $1 AND read_at IS NULL',
+        'SELECT COUNT(*) FROM notifications WHERE user_id = $1 AND read_at IS NULL',
         [userId]
       ),
     ]);
 
-    return success(res, {
-      notifications: notifResult.rows,
-      unread_count:  countResult.rows[0].unread_count,
+    return success(res, rows.rows, 200, {
+      total:  parseInt(total.rows[0].count,  10),
+      unread: parseInt(unread.rows[0].count, 10),
+      limit,
+      offset,
     });
   } catch (err) {
-    logger.error('listNotifications error', { error: err.message, userId });
+    logger.error('listNotifications error', { error: err.message });
     return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
   }
 }
 
 /**
- * PATCH /api/v1/notifications/:id/read
+ * PATCH /api/v1/notifications/:notificationId/read
+ * Marks a single notification as read (idempotent if already read → 404).
  *
- * Marks a single notification as read.  Idempotent: already-read
- * notifications are returned as-is with 200.
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
  */
-async function markOneRead(req, res) {
-  const userId         = req.user.id;
-  const notificationId = req.params.id;
+async function markRead(req, res) {
+  const userId             = req.user.id;
+  const { notificationId } = req.params;
 
   try {
     const result = await pool.query(
       `UPDATE notifications
-       SET    read_at = COALESCE(read_at, NOW())
-       WHERE  id = $1 AND user_id = $2
-       RETURNING id, type, payload, read_at, created_at`,
+       SET read_at = NOW()
+       WHERE id = $1 AND user_id = $2 AND read_at IS NULL
+       RETURNING *`,
       [notificationId, userId]
     );
-
     if (result.rowCount === 0) {
-      return error(res, 404, 'NOT_FOUND', 'Notification not found.');
+      return error(res, 404, 'NOT_FOUND', 'Notification not found or already read.');
     }
     return success(res, result.rows[0]);
   } catch (err) {
-    logger.error('markOneRead error', { error: err.message, userId, notificationId });
+    logger.error('markRead error', { error: err.message });
     return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
   }
 }
 
 /**
  * PATCH /api/v1/notifications/read-all
+ * Marks every unread notification for the current user as read.
+ * Returns { updated: <count> }.
  *
- * Marks all unread notifications for the current user as read.
- * Returns the count of rows updated.
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
  */
 async function markAllRead(req, res) {
   const userId = req.user.id;
-
   try {
     const result = await pool.query(
       `UPDATE notifications
-       SET    read_at = NOW()
-       WHERE  user_id = $1 AND read_at IS NULL`,
+       SET read_at = NOW()
+       WHERE user_id = $1 AND read_at IS NULL`,
       [userId]
     );
-    return success(res, { marked_read: result.rowCount });
+    return success(res, { updated: result.rowCount });
   } catch (err) {
-    logger.error('markAllRead error', { error: err.message, userId });
+    logger.error('markAllRead error', { error: err.message });
     return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
   }
 }
 
 /**
- * PATCH /api/v1/me/push-token
+ * POST /api/v1/notifications/push-token
+ * Register or update an Expo push token for the authenticated user.
  *
- * Stores (or clears) the user’s Expo push token.
- * Body: { push_token: string | null }
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
  */
-async function updatePushToken(req, res) {
-  const userId     = req.user.id;
-  const pushToken  = req.body.push_token ?? null;
+async function registerPushToken(req, res) {
+  const userId = req.user.id;
+  const parsed = registerTokenSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return error(res, 400, 'VALIDATION_ERROR', 'Invalid input.', parsed.error.errors);
+  }
+  const { expo_push_token } = parsed.data;
 
   try {
     await pool.query(
-      'UPDATE users SET push_token = $1 WHERE id = $2',
-      [pushToken, userId]
+      'UPDATE users SET expo_push_token = $1 WHERE id = $2',
+      [expo_push_token, userId]
     );
-    return success(res, { push_token: pushToken });
+    return success(res, { registered: true });
   } catch (err) {
-    logger.error('updatePushToken error', { error: err.message, userId });
+    logger.error('registerPushToken error', { error: err.message });
     return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
   }
 }
 
-module.exports = { listNotifications, markOneRead, markAllRead, updatePushToken };
+module.exports = { listNotifications, markRead, markAllRead, registerPushToken };

--- a/backend/src/controllers/notifications.controller.js
+++ b/backend/src/controllers/notifications.controller.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const pool           = require('../database/db');
+const { success, error } = require('../utils/response');
+const logger         = require('../utils/logger');
+
+const PAGE_SIZE_MAX = 50;
+const PAGE_SIZE_DEFAULT = 20;
+
+/**
+ * GET /api/v1/notifications
+ *
+ * Returns the authenticated user’s notifications, unread first then
+ * newest-first within each group.  Supports cursor-based pagination
+ * via `before` (a notification `created_at` ISO timestamp).
+ *
+ * Query params:
+ *   limit  {number}  1–50, default 20
+ *   before {string}  ISO timestamp cursor (exclusive)
+ *
+ * Response shape:
+ *   { data: { notifications: [...], unread_count: N }, meta: { ... } }
+ */
+async function listNotifications(req, res) {
+  const userId = req.user.id;
+  const limit  = Math.min(parseInt(req.query.limit) || PAGE_SIZE_DEFAULT, PAGE_SIZE_MAX);
+  const before = req.query.before || null;
+
+  try {
+    const params = [userId];
+    let cursorClause = '';
+    if (before) {
+      params.push(before);
+      cursorClause = `AND n.created_at < $${params.length}::timestamptz`;
+    }
+
+    const [notifResult, countResult] = await Promise.all([
+      pool.query(
+        `SELECT id, type, payload, read_at, created_at
+         FROM notifications n
+         WHERE user_id = $1 ${cursorClause}
+         ORDER BY
+           (read_at IS NOT NULL),   -- unread (NULL) sorts before read
+           created_at DESC
+         LIMIT ${limit}`,
+        params
+      ),
+      pool.query(
+        'SELECT COUNT(*)::int AS unread_count FROM notifications WHERE user_id = $1 AND read_at IS NULL',
+        [userId]
+      ),
+    ]);
+
+    return success(res, {
+      notifications: notifResult.rows,
+      unread_count:  countResult.rows[0].unread_count,
+    });
+  } catch (err) {
+    logger.error('listNotifications error', { error: err.message, userId });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+/**
+ * PATCH /api/v1/notifications/:id/read
+ *
+ * Marks a single notification as read.  Idempotent: already-read
+ * notifications are returned as-is with 200.
+ */
+async function markOneRead(req, res) {
+  const userId         = req.user.id;
+  const notificationId = req.params.id;
+
+  try {
+    const result = await pool.query(
+      `UPDATE notifications
+       SET    read_at = COALESCE(read_at, NOW())
+       WHERE  id = $1 AND user_id = $2
+       RETURNING id, type, payload, read_at, created_at`,
+      [notificationId, userId]
+    );
+
+    if (result.rowCount === 0) {
+      return error(res, 404, 'NOT_FOUND', 'Notification not found.');
+    }
+    return success(res, result.rows[0]);
+  } catch (err) {
+    logger.error('markOneRead error', { error: err.message, userId, notificationId });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+/**
+ * PATCH /api/v1/notifications/read-all
+ *
+ * Marks all unread notifications for the current user as read.
+ * Returns the count of rows updated.
+ */
+async function markAllRead(req, res) {
+  const userId = req.user.id;
+
+  try {
+    const result = await pool.query(
+      `UPDATE notifications
+       SET    read_at = NOW()
+       WHERE  user_id = $1 AND read_at IS NULL`,
+      [userId]
+    );
+    return success(res, { marked_read: result.rowCount });
+  } catch (err) {
+    logger.error('markAllRead error', { error: err.message, userId });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+/**
+ * PATCH /api/v1/me/push-token
+ *
+ * Stores (or clears) the user’s Expo push token.
+ * Body: { push_token: string | null }
+ */
+async function updatePushToken(req, res) {
+  const userId     = req.user.id;
+  const pushToken  = req.body.push_token ?? null;
+
+  try {
+    await pool.query(
+      'UPDATE users SET push_token = $1 WHERE id = $2',
+      [pushToken, userId]
+    );
+    return success(res, { push_token: pushToken });
+  } catch (err) {
+    logger.error('updatePushToken error', { error: err.message, userId });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+module.exports = { listNotifications, markOneRead, markAllRead, updatePushToken };

--- a/backend/src/controllers/reviews.controller.js
+++ b/backend/src/controllers/reviews.controller.js
@@ -1,14 +1,18 @@
-const pool = require('../database/db');
+'use strict';
+
+const pool   = require('../database/db');
 const { success, error } = require('../utils/response');
 const { recalculateAverageRating } = require('../services/reviews.service');
+const { createNotification } = require('../services/notification.service');
 const logger = require('../utils/logger');
 
 /**
  * POST /api/v1/exchanges/:exchangeId/reviews
  * Submit a review after a completed exchange.
+ * Emits a `new_review` notification to the reviewee.
  */
 async function createReview(req, res) {
-  const reviewerId = req.user.id;
+  const reviewerId  = req.user.id;
   const { exchangeId } = req.params;
   const { punctuality, pedagogy, respect, overall, comment } = req.body;
 
@@ -16,7 +20,6 @@ async function createReview(req, res) {
   try {
     await client.query('BEGIN');
 
-    // Verify exchange is completed and requester is a participant
     const exch = await client.query(
       `SELECT requester_id, partner_id, status FROM exchanges WHERE id = $1`,
       [exchangeId]
@@ -36,7 +39,6 @@ async function createReview(req, res) {
       return error(res, 400, 'INVALID_STATE', 'Can only review completed exchanges.');
     }
 
-    // Reviewee is the other participant
     const revieweeId = ex.requester_id === reviewerId ? ex.partner_id : ex.requester_id;
 
     const result = await client.query(
@@ -46,14 +48,25 @@ async function createReview(req, res) {
       [exchangeId, reviewerId, revieweeId, punctuality, pedagogy, respect, overall, comment || '']
     );
 
-    // Recalculate reviewee's average rating
     const newAvg = await recalculateAverageRating(client, revieweeId);
 
     await client.query('COMMIT');
+
+    // Notify the reviewee (after commit — fire-and-forget)
+    createNotification({
+      userId:  revieweeId,
+      type:    'new_review',
+      payload: {
+        exchangeId,
+        reviewerPseudo: req.user.pseudo,
+        overall,
+      },
+    }).catch(err => logger.warn('notification failed', { error: err.message }));
+
     return success(res, { review: result.rows[0], reviewee_new_average: newAvg }, 201);
   } catch (err) {
     await client.query('ROLLBACK');
-    if (err.code === '23505') { // unique violation
+    if (err.code === '23505') {
       return error(res, 409, 'DUPLICATE', 'You already reviewed this exchange.');
     }
     logger.error('createReview error', { error: err.message });
@@ -65,7 +78,7 @@ async function createReview(req, res) {
 
 /**
  * GET /api/v1/users/:userId/reviews
- * Get all reviews left for a user.
+ * Get all reviews left for a specific user.
  */
 async function getUserReviews(req, res) {
   const { userId } = req.params;

--- a/backend/src/database/migrations/005_notifications.sql
+++ b/backend/src/database/migrations/005_notifications.sql
@@ -1,0 +1,30 @@
+-- Migration 005: in-app notification system
+-- Run: psql $DATABASE_URL -f 005_notifications.sql
+
+-- ── Notification type enum ────────────────────────────────────────────
+DO $$ BEGIN
+  CREATE TYPE notification_type AS ENUM (
+    'exchange_requested',
+    'exchange_accepted',
+    'exchange_cancelled',
+    'new_message',
+    'new_review'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ── Notifications table ───────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS notifications (
+  id         UUID              PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID              NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type       notification_type NOT NULL,
+  payload    JSONB             NOT NULL DEFAULT '{}',
+  read_at    TIMESTAMPTZ       DEFAULT NULL,
+  created_at TIMESTAMPTZ       NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id   ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread    ON notifications(user_id, read_at) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_notifications_created   ON notifications(user_id, created_at DESC);
+
+-- ── Expo push token on users ──────────────────────────────────────────
+ALTER TABLE users ADD COLUMN IF NOT EXISTS push_token TEXT DEFAULT NULL;

--- a/backend/src/database/migrations/006_notifications.sql
+++ b/backend/src/database/migrations/006_notifications.sql
@@ -1,0 +1,28 @@
+-- Migration 006: notifications table + expo push token support
+
+DO $$ BEGIN
+  CREATE TYPE notification_type AS ENUM (
+    'exchange_request',
+    'exchange_accepted',
+    'exchange_cancelled',
+    'exchange_completed',
+    'new_message',
+    'new_review'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id         UUID              PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID              NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type       notification_type NOT NULL,
+  payload    JSONB             NOT NULL DEFAULT '{}',
+  read_at    TIMESTAMPTZ       DEFAULT NULL,
+  created_at TIMESTAMPTZ       NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id    ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread     ON notifications(user_id, read_at) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_notifications_created_at ON notifications(created_at);
+
+-- Optional Expo push token stored per user
+ALTER TABLE users ADD COLUMN IF NOT EXISTS expo_push_token TEXT DEFAULT NULL;

--- a/backend/src/routes/notifications.routes.js
+++ b/backend/src/routes/notifications.routes.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { Router }     = require('express');
+const { authenticate } = require('../middlewares/auth.middleware');
+const {
+  listNotifications,
+  markOneRead,
+  markAllRead,
+  updatePushToken,
+} = require('../controllers/notifications.controller');
+
+const router = Router();
+
+// All notification routes require a valid JWT
+router.use(authenticate);
+
+// ── List & counts ─────────────────────────────────────────────────────
+router.get('/',                listNotifications);
+
+// ── Mark read ─────────────────────────────────────────────────────────
+// /read-all MUST be declared before /:id so it is not swallowed as a param
+router.patch('/read-all',      markAllRead);
+router.patch('/:id/read',      markOneRead);
+
+module.exports = router;

--- a/backend/src/routes/notifications.routes.js
+++ b/backend/src/routes/notifications.routes.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const { Router }     = require('express');
+const { Router } = require('express');
 const { authenticate } = require('../middlewares/auth.middleware');
 const {
   listNotifications,
-  markOneRead,
+  markRead,
   markAllRead,
-  updatePushToken,
+  registerPushToken,
 } = require('../controllers/notifications.controller');
 
 const router = Router();
@@ -14,12 +14,16 @@ const router = Router();
 // All notification routes require a valid JWT
 router.use(authenticate);
 
-// ── List & counts ─────────────────────────────────────────────────────
-router.get('/',                listNotifications);
+// GET  /api/v1/notifications              — paginated list + unread count
+router.get('/',                        listNotifications);
 
-// ── Mark read ─────────────────────────────────────────────────────────
-// /read-all MUST be declared before /:id so it is not swallowed as a param
-router.patch('/read-all',      markAllRead);
-router.patch('/:id/read',      markOneRead);
+// PATCH /api/v1/notifications/read-all   — mark all as read (must be before :id route)
+router.patch('/read-all',              markAllRead);
+
+// PATCH /api/v1/notifications/:id/read   — mark single as read
+router.patch('/:notificationId/read',  markRead);
+
+// POST  /api/v1/notifications/push-token — register Expo push token
+router.post('/push-token',             registerPushToken);
 
 module.exports = router;

--- a/backend/src/services/notification.service.js
+++ b/backend/src/services/notification.service.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const pool   = require('../database/db');
+const logger = require('../utils/logger');
+
+/** @type {import('socket.io').Server|null} */
+let _io = null;
+
+/**
+ * Attach the Socket.io server instance so notifications can be
+ * delivered in real-time to the recipient's personal room.
+ * Called once from socket/index.js after the io server is created.
+ * @param {import('socket.io').Server} io
+ */
+function setIo(io) {
+  _io = io;
+}
+
+/**
+ * Persist a notification row to the DB and emit it via Socket.io
+ * to the recipient's personal room (`user:<userId>`).
+ * Also attempts an Expo push notification if the user has a token.
+ *
+ * @param {object} opts
+ * @param {string} opts.userId         - Recipient user UUID
+ * @param {string} opts.type           - notification_type enum value
+ * @param {object} [opts.payload={}]   - Arbitrary JSON metadata
+ * @returns {Promise<object>}          The created notification row
+ */
+async function createNotification({ userId, type, payload = {} }) {
+  try {
+    const result = await pool.query(
+      `INSERT INTO notifications (user_id, type, payload)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [userId, type, JSON.stringify(payload)]
+    );
+    const notification = result.rows[0];
+
+    // Real-time delivery via Socket.io personal room
+    if (_io) {
+      _io.to(`user:${userId}`).emit('notification', notification);
+    }
+
+    // Fire-and-forget Expo push (never throws to caller)
+    _sendExpoPush(userId, type, payload).catch(() => {});
+
+    return notification;
+  } catch (err) {
+    logger.error('createNotification error', { error: err.message, userId, type });
+    throw err;
+  }
+}
+
+/**
+ * Send an Expo push notification if the user has a registered push token
+ * and the EXPO_ACCESS_TOKEN env var is set.
+ * Errors are swallowed — push failures must never crash the main flow.
+ *
+ * @param {string} userId
+ * @param {string} type
+ * @param {object} payload
+ * @returns {Promise<void>}
+ */
+async function _sendExpoPush(userId, type, payload) {
+  if (!process.env.EXPO_ACCESS_TOKEN) return;
+  try {
+    const { rows } = await pool.query(
+      'SELECT expo_push_token FROM users WHERE id = $1 AND expo_push_token IS NOT NULL',
+      [userId]
+    );
+    if (rows.length === 0) return;
+
+    const body = _buildPushBody(type, payload);
+    // Use built-in fetch (Node 18+) or fall back to node-fetch
+    const fetchFn = typeof fetch !== 'undefined' ? fetch : require('node-fetch');
+    await fetchFn('https://exp.host/--/api/v2/push/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${process.env.EXPO_ACCESS_TOKEN}`,
+      },
+      body: JSON.stringify({
+        to:    rows[0].expo_push_token,
+        title: 'SkillSwap',
+        body,
+      }),
+    });
+  } catch (err) {
+    logger.warn('Expo push failed (non-fatal)', { error: err.message, userId });
+  }
+}
+
+/**
+ * Map a notification type to a human-readable push body string.
+ * @param {string} type
+ * @param {object} payload
+ * @returns {string}
+ */
+function _buildPushBody(type, payload) {
+  const map = {
+    exchange_request:   `${payload.requesterPseudo ?? 'Someone'} sent you an exchange request.`,
+    exchange_accepted:  'Your exchange request was accepted!',
+    exchange_cancelled: 'An exchange was cancelled.',
+    exchange_completed: 'An exchange has been completed. Leave a review!',
+    new_message:        `New message from ${payload.senderPseudo ?? 'someone'}.`,
+    new_review:         'You received a new review!',
+  };
+  return map[type] ?? 'You have a new notification.';
+}
+
+module.exports = { setIo, createNotification };

--- a/backend/src/services/notifications.service.js
+++ b/backend/src/services/notifications.service.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * Notification service.
+ *
+ * Provides a single entry point — `notify()` — used by every controller
+ * that triggers a notification-worthy event.  The function:
+ *
+ *   1. Persists a row in the `notifications` table.
+ *   2. Emits a Socket.io `notification` event to the user’s personal
+ *      room (`user:<userId>`) so connected clients update instantly.
+ *
+ * The Socket.io `io` instance is injected once at server start via
+ * `setIo()`.  Controllers that run before the socket server is ready
+ * (unlikely, but safe) will still persist to DB without crashing.
+ */
+
+const pool   = require('../database/db');
+const logger = require('../utils/logger');
+
+/** @type {import('socket.io').Server|null} */
+let _io = null;
+
+/**
+ * Inject the Socket.io server instance (called from server.js).
+ * @param {import('socket.io').Server} io
+ */
+function setIo(io) {
+  _io = io;
+}
+
+/**
+ * Create and deliver a notification.
+ *
+ * @param {object} opts
+ * @param {string} opts.userId   - UUID of the recipient
+ * @param {string} opts.type     - notification_type enum value
+ * @param {object} opts.payload  - JSONB payload (event-specific context)
+ * @param {import('pg').PoolClient} [opts.client] - optional PG client for transactional inserts
+ * @returns {Promise<object>}    The persisted notification row
+ */
+async function notify({ userId, type, payload = {}, client }) {
+  const db = client || pool;
+
+  const result = await db.query(
+    `INSERT INTO notifications (user_id, type, payload)
+     VALUES ($1, $2, $3)
+     RETURNING id, user_id, type, payload, read_at, created_at`,
+    [userId, type, JSON.stringify(payload)]
+  );
+
+  const notification = result.rows[0];
+
+  // Real-time delivery: fire-and-forget; never let socket errors
+  // bubble up to the caller or break an in-flight DB transaction.
+  try {
+    if (_io) {
+      _io.to(`user:${userId}`).emit('notification', notification);
+    }
+  } catch (err) {
+    logger.warn('Socket notification emit failed', { userId, type, error: err.message });
+  }
+
+  logger.debug('Notification created', { userId, type, id: notification.id });
+  return notification;
+}
+
+module.exports = { setIo, notify };

--- a/backend/src/socket/index.js
+++ b/backend/src/socket/index.js
@@ -1,15 +1,29 @@
+'use strict';
+
 const { Server } = require('socket.io');
-const jwt = require('jsonwebtoken');
+const jwt  = require('jsonwebtoken');
 const pool = require('../database/db');
 const logger = require('../utils/logger');
+const { setIo, createNotification } = require('../services/notification.service');
 
+/**
+ * Initialise the Socket.io server and attach event handlers.
+ * Also registers the io instance with the notification service so
+ * real-time notifications can be emitted from any controller.
+ *
+ * @param {import('http').Server} server - The Node.js HTTP server
+ * @returns {import('socket.io').Server}
+ */
 function initSocket(server) {
   const io = new Server(server, {
-    cors: { origin: '*' },
+    cors:        { origin: '*' },
     pingTimeout: 60000,
   });
 
-  // ── JWT Auth middleware for Socket.io ───────────────────────────────
+  // Share the io instance with the notification service
+  setIo(io);
+
+  // ── JWT Auth middleware ─────────────────────────────────────────────
   io.use((socket, next) => {
     const token = socket.handshake.auth?.token;
     if (!token) return next(new Error('Authentication required.'));
@@ -26,14 +40,12 @@ function initSocket(server) {
   io.on('connection', (socket) => {
     logger.debug('Socket connected', { userId: socket.userId });
 
-    // Join personal notification room
+    // Every authenticated user auto-joins their personal notification room
     socket.join(`user:${socket.userId}`);
 
-    // ── Join a conversation room ─────────────────────────────────
-    // Client emits: { exchangeId }
+    // ── Join a conversation room ────────────────────────────────────
     socket.on('join_exchange', async ({ exchangeId }) => {
       try {
-        // Verify user is a participant
         const result = await pool.query(
           'SELECT id FROM exchanges WHERE id = $1 AND (requester_id = $2 OR partner_id = $2)',
           [exchangeId, socket.userId]
@@ -50,8 +62,7 @@ function initSocket(server) {
       }
     });
 
-    // ── Send a message ───────────────────────────────────────
-    // Client emits: { exchangeId, content }
+    // ── Send a message ──────────────────────────────────────────────
     socket.on('send_message', async ({ exchangeId, content }) => {
       if (!exchangeId || !content?.trim()) return;
       if (content.length > 2000) {
@@ -60,9 +71,8 @@ function initSocket(server) {
       }
 
       try {
-        // Verify participant and exchange is active
         const exchResult = await pool.query(
-          `SELECT id, status FROM exchanges
+          `SELECT id, status, requester_id, partner_id FROM exchanges
            WHERE id = $1 AND (requester_id = $2 OR partner_id = $2)`,
           [exchangeId, socket.userId]
         );
@@ -71,7 +81,6 @@ function initSocket(server) {
           return;
         }
 
-        // Persist to DB
         const msgResult = await pool.query(
           `INSERT INTO messages (exchange_id, sender_id, content)
            VALUES ($1, $2, $3)
@@ -79,21 +88,31 @@ function initSocket(server) {
           [exchangeId, socket.userId, content.trim()]
         );
         const msg = msgResult.rows[0];
+        const payload = { ...msg, sender: { id: socket.userId, pseudo: socket.pseudo } };
 
-        const payload = {
-          ...msg,
-          sender: { id: socket.userId, pseudo: socket.pseudo },
-        };
-
-        // Broadcast to all room members (including sender for confirmation)
+        // Broadcast to everyone in the exchange room
         io.to(`exchange:${exchangeId}`).emit('new_message', payload);
+
+        // Notify the OTHER participant via their personal room
+        const ex          = exchResult.rows[0];
+        const recipientId = ex.requester_id === socket.userId ? ex.partner_id : ex.requester_id;
+        createNotification({
+          userId:  recipientId,
+          type:    'new_message',
+          payload: {
+            exchangeId,
+            messageId:   msg.id,
+            senderPseudo: socket.pseudo,
+          },
+        }).catch(err => logger.warn('notification failed', { error: err.message }));
+
       } catch (err) {
         logger.error('send_message error', { error: err.message });
         socket.emit('error', { message: 'Failed to send message.' });
       }
     });
 
-    // ── Typing indicator ──────────────────────────────────────
+    // ── Typing indicator ────────────────────────────────────────────
     socket.on('typing', ({ exchangeId }) => {
       socket.to(`exchange:${exchangeId}`).emit('partner_typing', {
         userId: socket.userId,


### PR DESCRIPTION
## Summary
Closes #6

## What's included

### 🗄️ Migration
- `006_notifications.sql` — `notifications` table with `id`, `user_id`, `type` (enum), `payload` JSONB, `read_at`, `created_at`
- Adds `expo_push_token TEXT` column to `users`
- Indexes on `user_id`, `read_at` (partial: unread only), `created_at`

### 🔔 Notification Service (`services/notification.service.js`)
- `createNotification({ userId, type, payload })` — persists to DB, emits to Socket.io personal room `user:<id>`, fire-and-forgets Expo push
- `setIo(io)` — called once from `socket/index.js` after server start
- `_sendExpoPush()` — uses `EXPO_ACCESS_TOKEN` env var, swallows errors so push failures never crash the main flow

### 🌐 REST Endpoints (`routes/notifications.routes.js` + `controllers/notifications.controller.js`)
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/notifications` | Paginated list, unread count in `meta` |
| `PATCH` | `/api/v1/notifications/read-all` | Mark all unread as read |
| `PATCH` | `/api/v1/notifications/:id/read` | Mark single as read |
| `POST` | `/api/v1/notifications/push-token` | Register Expo push token |

### ⚡ Event Hooks
- `exchanges.controller.js` — emits `exchange_request` on create, `exchange_accepted`/`exchange_cancelled` on respond, `exchange_completed` (both participants) on dual-confirm
- `reviews.controller.js` — emits `new_review` to reviewee after commit
- `socket/index.js` — emits `new_message` notification to recipient on every WS message

### 🔌 Socket.io
- `socket/index.js` now calls `setIo(io)` so the notification service can emit to personal rooms from any controller

### 🗺️ app.js
- Mounts `notificationsRoutes` at `/api/v1/notifications`

## Acceptance criteria checklist
- [x] `notifications` table with correct schema
- [x] Insert triggers on exchange/message/review events
- [x] `GET /notifications` endpoint
- [x] `PATCH` read / read-all endpoints
- [x] Socket.io `notification` event emitted to personal room
- [x] Optional Expo push token support (`POST /push-token` + `EXPO_ACCESS_TOKEN` env)