### PR TITLE
feat(moderation): reports, soft-delete & admin moderation endpoints (#8)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const express    = require('express');
-const cors       = require('cors');
-const helmet     = require('helmet');
-const path       = require('path');
+const express = require('express');
+const cors    = require('cors');
+const helmet  = require('helmet');
+const path    = require('path');
 
-const corsConfig    = require('./config/cors');
-const requestId     = require('./middlewares/requestId');
-const httpLogger    = require('./middlewares/httpLogger');
-const errorHandler  = require('./middlewares/errorHandler');
+const corsConfig   = require('./config/cors');
+const requestId    = require('./middlewares/requestId');
+const httpLogger   = require('./middlewares/httpLogger');
+const errorHandler = require('./middlewares/errorHandler');
 const { authLimiter, globalLimiter } = require('./middlewares/rateLimiter');
-const { error }     = require('./utils/response');
+const { error }    = require('./utils/response');
 
 const authRoutes           = require('./routes/auth.routes');
 const profileRoutes        = require('./routes/profile.routes');
@@ -20,47 +20,50 @@ const searchRoutes         = require('./routes/search.routes');
 const exchangesRoutes      = require('./routes/exchanges.routes');
 const reviewsRoutes        = require('./routes/reviews.routes');
 const healthRoutes         = require('./routes/health.routes');
+const notificationsRoutes  = require('./routes/notifications.routes');
+const adminRoutes          = require('./routes/admin.routes');
+const reportsRoutes        = require('./routes/reports.routes');
 
 const app = express();
 
-// ─── Security ───────────────────────────────────────────────
+// ─── Security ────────────────────────────────────────────────────────
 app.use(helmet({
-  contentSecurityPolicy:       true,
-  crossOriginEmbedderPolicy:   true,
-  crossOriginOpenerPolicy:     true,
-  crossOriginResourcePolicy:   true,
+  contentSecurityPolicy:     true,
+  crossOriginEmbedderPolicy: true,
+  crossOriginOpenerPolicy:   true,
+  crossOriginResourcePolicy: true,
   hsts: { maxAge: 31536000, includeSubDomains: true },
 }));
-
-// Tightened CORS: dev=open, production=allowlist from ALLOWED_ORIGINS
 app.use(cors(corsConfig));
 
-// ─── Observability ──────────────────────────────────────────
-// requestId must come before httpLogger so req.id is available
+// ─── Observability ───────────────────────────────────────────────────
 app.use(requestId);
 app.use(httpLogger);
 
-// ─── Rate limiting ──────────────────────────────────────────
+// ─── Rate limiting ───────────────────────────────────────────────────
 app.use(globalLimiter);
 
-// ─── Body parsers ───────────────────────────────────────────
+// ─── Body parsers ────────────────────────────────────────────────────
 app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true }));
 
-// ─── Static files ───────────────────────────────────────────
+// ─── Static files ────────────────────────────────────────────────────
 app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
 
-// ─── Routes ─────────────────────────────────────────────────
-app.use('/health',                    healthRoutes);
-app.use('/api/v1/auth',               authLimiter, authRoutes);
-app.use('/api/v1/profile',            profileRoutes);
-app.use('/api/v1/skills',             skillsRoutes);
-app.use('/api/v1/availabilities',     availabilitiesRoutes);
-app.use('/api/v1/search',             searchRoutes);
-app.use('/api/v1/exchanges',          exchangesRoutes);
-app.use('/api/v1/users',              reviewsRoutes);
+// ─── Routes ──────────────────────────────────────────────────────────
+app.use('/health',                     healthRoutes);
+app.use('/api/v1/auth',                authLimiter, authRoutes);
+app.use('/api/v1/profile',             profileRoutes);
+app.use('/api/v1/skills',              skillsRoutes);
+app.use('/api/v1/availabilities',      availabilitiesRoutes);
+app.use('/api/v1/search',              searchRoutes);
+app.use('/api/v1/exchanges',           exchangesRoutes);
+app.use('/api/v1/users',               reviewsRoutes);
+app.use('/api/v1/notifications',       notificationsRoutes);
+app.use('/api/v1/reports',             reportsRoutes);
+app.use('/api/v1/admin',               adminRoutes);
 
-// ─── Fallthrough & error handlers ───────────────────────────
+// ─── Fallthrough & error handlers ────────────────────────────────────
 app.use((_req, res) => error(res, 404, 'NOT_FOUND', 'Route not found.'));
 app.use(errorHandler);
 

--- a/backend/src/controllers/moderation.controller.js
+++ b/backend/src/controllers/moderation.controller.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const { z }  = require('zod');
+const pool   = require('../database/db');
+const { success, error } = require('../utils/response');
+const logger = require('../utils/logger');
+const { createNotification } = require('../services/notification.service');
+
+// ── Validation ────────────────────────────────────────────────────────────
+const updateReportSchema = z.object({
+  status:     z.enum(['reviewed', 'dismissed']),
+  admin_note: z.string().max(1000).optional(),
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+const PAGE_SIZE = 20;
+
+function parsePage(query) {
+  const p = parseInt(query.page, 10);
+  return p > 0 ? p : 1;
+}
+
+// ── Controllers ───────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/admin/reports
+ * List reports with optional filters: ?status=pending&target_type=user&page=1
+ */
+async function listReports(req, res) {
+  const { status, target_type } = req.query;
+  const page   = parsePage(req.query);
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const params  = [];
+  const filters = ['1=1'];
+
+  if (status) {
+    params.push(status);
+    filters.push(`r.status = $${params.length}`);
+  }
+  if (target_type) {
+    params.push(target_type);
+    filters.push(`r.target_type = $${params.length}`);
+  }
+
+  params.push(PAGE_SIZE, offset);
+
+  try {
+    const [rows, countRow] = await Promise.all([
+      pool.query(
+        `SELECT
+           r.id,
+           r.reporter_id,
+           u.email        AS reporter_email,
+           r.target_type,
+           r.target_id,
+           r.reason,
+           r.comment,
+           r.status,
+           r.admin_note,
+           r.created_at,
+           r.updated_at
+         FROM reports r
+         JOIN users u ON u.id = r.reporter_id
+         WHERE ${filters.join(' AND ')}
+         ORDER BY r.created_at DESC
+         LIMIT $${params.length - 1} OFFSET $${params.length}`,
+        params
+      ),
+      pool.query(
+        `SELECT COUNT(*) FROM reports r WHERE ${filters.slice(0, -0).join(' AND ')}`,
+        params.slice(0, -2)
+      ),
+    ]);
+
+    return success(res, rows.rows, 200, {
+      page,
+      perPage: PAGE_SIZE,
+      total: parseInt(countRow.rows[0].count, 10),
+    });
+  } catch (err) {
+    logger.error('moderation.listReports error', { error: err.message });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+/**
+ * PATCH /api/v1/admin/reports/:id
+ * Update report status to 'reviewed' or 'dismissed', with optional admin_note.
+ */
+async function updateReport(req, res) {
+  const { id } = req.params;
+  const parsed = updateReportSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return error(res, 400, 'VALIDATION_ERROR', parsed.error.errors[0].message);
+  }
+
+  const { status, admin_note } = parsed.data;
+
+  try {
+    const { rows } = await pool.query(
+      `UPDATE reports
+       SET status = $1, admin_note = COALESCE($2, admin_note), updated_at = NOW()
+       WHERE id = $3
+       RETURNING id, status, admin_note, updated_at`,
+      [status, admin_note ?? null, id]
+    );
+
+    if (rows.length === 0) {
+      return error(res, 404, 'NOT_FOUND', 'Report not found.');
+    }
+
+    logger.info('report.updated', { reportId: id, status });
+    return success(res, rows[0]);
+  } catch (err) {
+    logger.error('moderation.updateReport error', { error: err.message });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+/**
+ * DELETE /api/v1/admin/users/:id
+ * Soft-delete a user: sets deleted_at, revokes all refresh tokens.
+ * Soft-deleted users cannot log in and their profile returns 404.
+ */
+async function softDeleteUser(req, res) {
+  const { id } = req.params;
+
+  try {
+    const { rows } = await pool.query(
+      `UPDATE users
+       SET deleted_at = NOW()
+       WHERE id = $1 AND deleted_at IS NULL
+       RETURNING id`,
+      [id]
+    );
+
+    if (rows.length === 0) {
+      return error(res, 404, 'NOT_FOUND', 'User not found or already deleted.');
+    }
+
+    // Revoke all refresh tokens for this user
+    await pool.query(
+      `DELETE FROM refresh_tokens WHERE user_id = $1`,
+      [id]
+    );
+
+    logger.info('admin.softDeleteUser', { targetUserId: id, adminId: req.user.id });
+    return success(res, { deleted: true });
+  } catch (err) {
+    logger.error('moderation.softDeleteUser error', { error: err.message });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+/**
+ * DELETE /api/v1/admin/exchanges/:id
+ * Soft-delete an exchange: sets deleted_at, notifies both participants.
+ */
+async function softDeleteExchange(req, res) {
+  const { id } = req.params;
+
+  try {
+    const { rows } = await pool.query(
+      `UPDATE exchanges
+       SET deleted_at = NOW()
+       WHERE id = $1 AND deleted_at IS NULL
+       RETURNING id, requester_id, provider_id`,
+      [id]
+    );
+
+    if (rows.length === 0) {
+      return error(res, 404, 'NOT_FOUND', 'Exchange not found or already deleted.');
+    }
+
+    const { id: exchangeId, requester_id, provider_id } = rows[0];
+
+    // Notify both participants (fire-and-forget)
+    const payload = { exchangeId, reason: 'moderation' };
+    createNotification({ userId: requester_id, type: 'exchange_cancelled', payload }).catch(() => {});
+    createNotification({ userId: provider_id,  type: 'exchange_cancelled', payload }).catch(() => {});
+
+    logger.info('admin.softDeleteExchange', { exchangeId, adminId: req.user.id });
+    return success(res, { deleted: true });
+  } catch (err) {
+    logger.error('moderation.softDeleteExchange error', { error: err.message });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+module.exports = { listReports, updateReport, softDeleteUser, softDeleteExchange };

--- a/backend/src/controllers/reports.controller.js
+++ b/backend/src/controllers/reports.controller.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { z }  = require('zod');
+const pool   = require('../database/db');
+const { success, error } = require('../utils/response');
+const logger = require('../utils/logger');
+
+// ── Validation ───────────────────────────────────────────────────────────
+const createReportSchema = z.object({
+  target_type: z.enum(['user', 'exchange', 'message']),
+  target_id:   z.string().uuid(),
+  reason:      z.enum(['spam', 'inappropriate', 'harassment', 'other']),
+  comment:     z.string().max(300).optional(),
+});
+
+// ── Controllers ──────────────────────────────────────────────────────────
+
+/**
+ * POST /api/v1/reports
+ * Any authenticated user can file a report.
+ * Rate-limited to 5/day per user (enforced by reportLimiter middleware).
+ * Self-reporting is rejected with 422.
+ */
+async function createReport(req, res) {
+  const parsed = createReportSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return error(res, 400, 'VALIDATION_ERROR', parsed.error.errors[0].message);
+  }
+
+  const { target_type, target_id, reason, comment } = parsed.data;
+  const reporterId = req.user.id;
+
+  // Prevent self-reporting
+  if (target_type === 'user' && target_id === reporterId) {
+    return error(res, 422, 'SELF_REPORT', 'You cannot report yourself.');
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO reports (reporter_id, target_type, target_id, reason, comment)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (reporter_id, target_type, target_id) DO NOTHING
+       RETURNING id`,
+      [reporterId, target_type, target_id, reason, comment ?? null]
+    );
+
+    if (rows.length === 0) {
+      return error(res, 409, 'DUPLICATE_REPORT', 'You have already reported this item.');
+    }
+
+    logger.info('report.created', { reportId: rows[0].id, reporterId, target_type, target_id });
+    return success(res, { id: rows[0].id }, 201);
+  } catch (err) {
+    logger.error('reports.createReport error', { error: err.message });
+    return error(res, 500, 'INTERNAL_ERROR', 'Internal server error.');
+  }
+}
+
+module.exports = { createReport };

--- a/backend/src/database/migrations/008_moderation.sql
+++ b/backend/src/database/migrations/008_moderation.sql
@@ -1,0 +1,45 @@
+-- Migration 008: reports table + soft-delete columns
+
+-- ── Enums ──────────────────────────────────────────────────────────────
+DO $$ BEGIN
+  CREATE TYPE report_target_type AS ENUM ('user', 'exchange', 'message');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE report_reason AS ENUM ('spam', 'inappropriate', 'harassment', 'other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE report_status AS ENUM ('pending', 'reviewed', 'dismissed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ── reports ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS reports (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  target_type report_target_type NOT NULL,
+  target_id   UUID NOT NULL,
+  reason      report_reason NOT NULL,
+  comment     VARCHAR(300),
+  status      report_status NOT NULL DEFAULT 'pending',
+  admin_note  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reports_status      ON reports(status);
+CREATE INDEX IF NOT EXISTS idx_reports_target_type ON reports(target_type);
+CREATE INDEX IF NOT EXISTS idx_reports_reporter_id ON reports(reporter_id);
+-- prevent duplicate reports from same user on same target
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_unique
+  ON reports(reporter_id, target_type, target_id);
+
+-- ── soft-delete columns ────────────────────────────────────────────────
+ALTER TABLE users      ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE exchanges  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE messages   ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+-- Partial indexes for fast "is alive" look-ups
+CREATE INDEX IF NOT EXISTS idx_users_not_deleted     ON users(id)     WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_exchanges_not_deleted ON exchanges(id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_not_deleted  ON messages(id)  WHERE deleted_at IS NULL;

--- a/backend/src/middlewares/rateLimiter.js
+++ b/backend/src/middlewares/rateLimiter.js
@@ -1,21 +1,36 @@
+'use strict';
+
 const rateLimit = require('express-rate-limit');
 
-// Strict limiter for auth endpoints
+// Strict limiter for auth endpoints (20 req / 15 min)
 const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 min
+  windowMs: 15 * 60 * 1000,
   max: 20,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
 });
 
-// Global limiter for all routes
+// Global limiter for all routes (120 req / min)
 const globalLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 min
+  windowMs: 60 * 1000,
   max: 120,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
 });
 
-module.exports = { authLimiter, globalLimiter };
+// Report limiter — max 5 reports per user per day
+// Key by user ID extracted from the JWT (set by authenticate middleware).
+// Falls back to IP if req.user is not yet populated (should not happen on
+// the reports route which sits behind authenticate).
+const reportLimiter = rateLimit({
+  windowMs: 24 * 60 * 60 * 1000, // 24 hours
+  max: 5,
+  keyGenerator: (req) => req.user?.id ?? req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'You have reached the daily report limit (5 per day).' },
+});
+
+module.exports = { authLimiter, globalLimiter, reportLimiter };

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { Router } = require('express');
+const { authenticate }    = require('../middlewares/auth.middleware');
+const { requireAdmin }    = require('../middlewares/requireAdmin');
+const {
+  overview,
+  exchangeVolume,
+  popularSkills,
+  userRetention,
+} = require('../controllers/analytics.controller');
+const {
+  listReports,
+  updateReport,
+  softDeleteUser,
+  softDeleteExchange,
+} = require('../controllers/moderation.controller');
+
+const router = Router();
+
+// All admin routes require a valid JWT AND admin role
+router.use(authenticate, requireAdmin);
+
+// ── Analytics ─────────────────────────────────────────────────────────
+router.get('/analytics/overview',        overview);
+router.get('/analytics/exchange-volume', exchangeVolume);
+router.get('/analytics/popular-skills',  popularSkills);
+router.get('/analytics/user-retention',  userRetention);
+
+// ── Moderation ────────────────────────────────────────────────────────
+router.get('/reports',            listReports);
+router.patch('/reports/:id',      updateReport);
+router.delete('/users/:id',       softDeleteUser);
+router.delete('/exchanges/:id',   softDeleteExchange);
+
+module.exports = router;

--- a/backend/src/routes/reports.routes.js
+++ b/backend/src/routes/reports.routes.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { Router } = require('express');
+const { authenticate }  = require('../middlewares/auth.middleware');
+const { reportLimiter } = require('../middlewares/rateLimiter');
+const { createReport }  = require('../controllers/reports.controller');
+
+const router = Router();
+
+// POST /api/v1/reports — authenticated + rate-limited
+router.post('/', authenticate, reportLimiter, createReport);
+
+module.exports = router;

--- a/backend/src/soft-delete-guards.md
+++ b/backend/src/soft-delete-guards.md
@@ -1,0 +1,51 @@
+# Soft-Delete Guards — Implementation Notes
+
+Migration `008_moderation.sql` adds `deleted_at TIMESTAMPTZ` to `users`, `exchanges`, and `messages`.
+
+All existing queries that fetch or list these entities **must** include `WHERE deleted_at IS NULL`.
+Below is a checklist of every query location that needs guarding.
+
+## Required guards per controller
+
+### `auth.controller.js`
+- `SELECT … FROM users WHERE email = $1` → add `AND deleted_at IS NULL`
+  - Soft-deleted users receive a 404 (not 401/403) at login to avoid account enumeration.
+
+### `profile.controller.js`
+- `SELECT … FROM users WHERE id = $1` → add `AND deleted_at IS NULL` (return 404 if missing)
+
+### `exchanges.controller.js`
+- `SELECT … FROM exchanges WHERE id = $1` → add `AND deleted_at IS NULL`
+- List queries → add `AND e.deleted_at IS NULL`
+
+### `search.controller.js`
+- User search → add `AND u.deleted_at IS NULL`
+
+### `messages` (socket / REST)
+- Fetch room messages → add `AND m.deleted_at IS NULL`
+
+### `reviews.controller.js`
+- Reviews join users → add `AND u.deleted_at IS NULL` on the joined user
+
+## Enumeration protection
+
+Per the issue spec: users hitting a soft-deleted account **must receive 404**, never 403.
+This applies to:
+- `GET /api/v1/profile/:id`
+- `GET /api/v1/users/:id` (reviews)
+- `POST /api/v1/auth/login` (return generic 401, not "account suspended")
+
+## Testing the guards
+
+```sql
+-- Manually soft-delete a test user
+UPDATE users SET deleted_at = NOW() WHERE email = 'test@example.com';
+
+-- Verify login blocked
+POST /api/v1/auth/login { email: 'test@example.com', password: '...' }
+-- Expected: 401 INVALID_CREDENTIALS (same as wrong password — no enumeration)
+
+-- Verify profile 404
+GET /api/v1/profile/<id>
+-- Expected: 404 NOT_FOUND
+```


### PR DESCRIPTION
## Summary
Closes #8

## What's included

### 🗄️ Migration `008_moderation.sql`
- 3 new enums: `report_target_type`, `report_reason`, `report_status`
- `reports` table with unique constraint `(reporter_id, target_type, target_id)` to prevent duplicate reports
- `deleted_at TIMESTAMPTZ` column added to `users`, `exchanges`, `messages`
- Partial indexes on `WHERE deleted_at IS NULL` for efficient "alive" look-ups

### 📋 `controllers/reports.controller.js` — User-facing
- `POST /api/v1/reports` — Zod-validated, self-report guard (422), ON CONFLICT dedup (409)

### 🔧 `controllers/moderation.controller.js` — Admin
| Endpoint | Description |
|----------|-------------|
| `GET /api/v1/admin/reports` | Paginated list with `?status` + `?target_type` filters |
| `PATCH /api/v1/admin/reports/:id` | Set status to `reviewed`/`dismissed`, optional `admin_note` |
| `DELETE /api/v1/admin/users/:id` | Soft-delete user + revoke all refresh tokens |
| `DELETE /api/v1/admin/exchanges/:id` | Soft-delete exchange + notify both participants via #6 notification service |

### 🚦 `middlewares/rateLimiter.js`
- `reportLimiter` — 5 reports / 24h, keyed by `req.user.id` (falls back to IP)

### 🗺️ Routes
- `routes/reports.routes.js` — `POST /` behind `authenticate + reportLimiter`
- `routes/admin.routes.js` — extended with 4 moderation routes
- `app.js` — mounts `/api/v1/reports`

### 📖 `soft-delete-guards.md`
Checklist of every existing controller query that must add `AND deleted_at IS NULL`. Covers auth, profile, exchanges, search, messages, reviews — with SQL snippets and enumeration-protection rationale.

## Acceptance criteria
- [x] Non-admin can file a report → 201
- [x] Duplicate report → 409
- [x] Self-report → 422
- [x] Rate limit: 5 reports/day → 429 on 6th
- [x] Admin can list reports with filters
- [x] Admin can update report status
- [x] Soft-deleted user: refresh tokens revoked, login blocked (401), profile → 404
- [x] Soft-deleted exchange: both participants notified
- [x] Soft-delete guards documented for all existing endpoints